### PR TITLE
Fix amino acid indexing in variant annotations

### DIFF
--- a/R/snv.R
+++ b/R/snv.R
@@ -479,7 +479,7 @@ snv <- function(input_file = NULL, ref_file = system.file("extdata", package="ch
                             } else {codon_variant_ntg[c_id] <- tolower(seqinr::comp(as.character(s_$ALT)))}
 
                             codon_dna_mut = c(codon_dna_mut, paste(codon_variant_ntg, collapse="")) # mutant codon
-                            aa_ = grep(as.character(s_$POS), codon_pos) ; aa_pos = c(aa_pos, aa_) # amino acid position
+                            aa_ = grep(as.character(s_$POS), codon_pos)[1] ; aa_pos = c(aa_pos, aa_) # amino acid position
 
                             codon_variant_translate <- as.character(seqinr::translate(codon_variant))
                             codon_variant_ntg_translate <- as.character(seqinr::translate(codon_variant_ntg))


### PR DESCRIPTION
@jkokosar 
If a mutation occurs at nucleotide position 575, this script reports the amino acids translated from the codons containing nucleotides 575 and 1575 both as variants. We want only the first (smallest matching) result of this search every time. 