### PR TITLE
Fix indel.R missing object and regex overflow errors

### DIFF
--- a/R/indel.R
+++ b/R/indel.R
@@ -535,11 +535,9 @@ indel <- function(input_file = NULL, ref_file = system.file("extdata", package="
             write.table(var_filtered_concise, paste(out_dir,"/","variant_filtered.txt",sep=""), sep="\t", quote=F, row.names=F)
 
             #vcf file for IGV viewer
-            vcf_one_alt_idx = paste(vcf_one_alt$CHROM,vcf_one_alt$POS, sep=":")
-            var_filtered_concise_idx = paste(var_filtered_concise$CHROM,var_filtered_concise$POS, sep=":")
-            var_filtered_concise_idx = unique(var_filtered_concise_idx)
-            idx = grep(paste(var_filtered_concise_idx,collapse = "|"),vcf_one_alt_idx)
-            vcf_one_alt = vcf_one_alt[idx,]; names(vcf_one_alt)[1] = "#CHROM"
+            chrom_ids = vcf_one_alt$CHROM %in% var_filtered_concise$CHROM
+            pos_ids = vcf_one_alt$POS %in% var_filtered_concise$POS
+            vcf_one_alt = vcf_one_alt[chrom_ids & pos_ids ,] ; names(vcf_one_alt)[1] = "#CHROM"
             vcf_version <- readLines(input_file,n = 1)
             writeLines(vcf_version,con =  paste(out_dir,"/","variants.vcf",sep=""))
             write.table(vcf_one_alt, paste(out_dir,"/","variants.vcf",sep=""), sep="\t", quote=F, row.names=F,append = T)

--- a/R/indel.R
+++ b/R/indel.R
@@ -268,7 +268,7 @@ indel <- function(input_file = NULL, ref_file = system.file("extdata", package="
         if(dim(vcf_multi_alt_split)[1]>0){
             alt_freq <- dplyr::select(vcf_multi_alt_split, contains("_freq"))
             alt_freq_par <- dplyr::select(alt_freq, contains(names_par)) # frequency of the reference allele in the parental strain
-            depth_ <- dplyr::select(vcf_multiple_alt_split,contains("_DP"))
+            depth_ <- dplyr::select(vcf_multi_alt_split, contains("_DP"))
             depth_par <- dplyr::select(depth_,contains(names_par)) # read depth in the parental strain
             for(n_ in names_mut){
                 alt_freq_tmp <- dplyr::select(alt_freq, contains(n_)) # frequency of the reference allele in a given mutant strain
@@ -277,7 +277,7 @@ indel <- function(input_file = NULL, ref_file = system.file("extdata", package="
                 freq_diff_l <- rowSums(freq_diff_l) == length(col_)
                 read_depth_l <- depth_par >= read_depth & depth_tmp >= read_depth # the read depth threshold
                 pass_ <- freq_diff_l & read_depth_l # variants that pass both the frequency difference and read depth threshold
-                vcf_filter_tmp <- vcf_multiple_alt_split_split[pass_,]
+                vcf_filter_tmp <- vcf_multi_alt_split[pass_,]
 
                 if(dim(vcf_filter_tmp)[1] > 0) {
                     # Add a column with strain names

--- a/R/indel_chr2.R
+++ b/R/indel_chr2.R
@@ -528,11 +528,9 @@ indel_chr2 <- function(input_file = NULL, ref_file = system.file("extdata", pack
             write.table(var_filtered_concise, paste(out_dir,"/","variant_filtered.txt",sep=""), sep="\t", quote=F, row.names=F)
 
             #vcf file for IGV viewer
-            vcf_one_alt_idx = paste(vcf_one_alt$CHROM,vcf_one_alt$POS, sep=":")
-            var_filtered_concise_idx = paste(var_filtered_concise$CHROM,var_filtered_concise$POS, sep=":")
-            var_filtered_concise_idx = unique(var_filtered_concise_idx)
-            idx = grep(paste(var_filtered_concise_idx,collapse = "|"),vcf_one_alt_idx)
-            vcf_one_alt = vcf_one_alt[idx,]; names(vcf_one_alt)[1] = "#CHROM"
+            chrom_ids = vcf_one_alt$CHROM %in% var_filtered_concise$CHROM
+            pos_ids = vcf_one_alt$POS %in% var_filtered_concise$POS
+            vcf_one_alt = vcf_one_alt[chrom_ids & pos_ids ,] ; names(vcf_one_alt)[1] = "#CHROM"
             vcf_version <- readLines(input_file,n = 1)
             writeLines(vcf_version,con =  paste(out_dir,"/","variants.vcf",sep=""))
             write.table(vcf_one_alt, paste(out_dir,"/","variants.vcf",sep=""), sep="\t", quote=F, row.names=F,append = T)

--- a/R/snv.R
+++ b/R/snv.R
@@ -683,11 +683,9 @@ snv <- function(input_file = NULL, ref_file = system.file("extdata", package="ch
             write.table(var_filtered_concise, paste(out_dir,"/","variant_filtered.txt",sep=""), sep="\t", quote=F, row.names=F)
 
             #vcf file for IGV viewer
-            vcf_one_alt_idx = paste(vcf_one_alt$CHROM,vcf_one_alt$POS, sep=":")
-            var_filtered_concise_idx = paste(var_filtered_concise$CHROM,var_filtered_concise$POS, sep=":")
-            var_filtered_concise_idx = unique(var_filtered_concise_idx)
-            idx = grep(paste(var_filtered_concise_idx,collapse = "|"),vcf_one_alt_idx)
-            vcf_one_alt = vcf_one_alt[idx,]; names(vcf_one_alt)[1] = "#CHROM"
+            chrom_ids = vcf_one_alt$CHROM %in% var_filtered_concise$CHROM
+            pos_ids = vcf_one_alt$POS %in% var_filtered_concise$POS
+            vcf_one_alt = vcf_one_alt[chrom_ids & pos_ids ,] ; names(vcf_one_alt)[1] = "#CHROM"
             vcf_version <- readLines(input_file,n = 1)
             writeLines(vcf_version,con =  paste(out_dir,"/","variants.vcf",sep=""))
             write.table(vcf_one_alt, paste(out_dir,"/","variants.vcf",sep=""), sep="\t", quote=F, row.names=F,append = T)

--- a/R/snv_chr2.R
+++ b/R/snv_chr2.R
@@ -680,11 +680,9 @@ snv_chr2 <- function(input_file = NULL, ref_file = system.file("extdata", packag
             write.table(var_filtered_concise, paste(out_dir,"/","variant_filtered.txt",sep=""), sep="\t", quote=F, row.names=F)
 
             #vcf file for IGV viewer
-            vcf_one_alt_idx = paste(vcf_one_alt$CHROM,vcf_one_alt$POS, sep=":")
-            var_filtered_concise_idx = paste(var_filtered_concise$CHROM,var_filtered_concise$POS, sep=":")
-            var_filtered_concise_idx = unique(var_filtered_concise_idx)
-            idx = grep(paste(var_filtered_concise_idx,collapse = "|"),vcf_one_alt_idx)
-            vcf_one_alt = vcf_one_alt[idx,]; names(vcf_one_alt)[1] = "#CHROM"
+            chrom_ids = vcf_one_alt$CHROM %in% var_filtered_concise$CHROM
+            pos_ids = vcf_one_alt$POS %in% var_filtered_concise$POS
+            vcf_one_alt = vcf_one_alt[chrom_ids & pos_ids ,] ; names(vcf_one_alt)[1] = "#CHROM"
             vcf_version <- readLines(input_file,n = 1)
             writeLines(vcf_version,con =  paste(out_dir,"/","variants.vcf",sep=""))
             write.table(vcf_one_alt, paste(out_dir,"/","variants.vcf",sep=""), sep="\t", quote=F, row.names=F,append = T)


### PR DESCRIPTION
This fixes two issues:
1. indel.R contained two typos that threw missing object errors. 
2. All four of the different analyses suffered from an error in which a sufficiently large set of variants (somewhere between 2000 and 4000) would cause a regex overflow issue during one of the table-filtering steps. 

All four analyses have now been tested on real user data, and they successfully complete without error. 